### PR TITLE
Add token id to the sms and decrypt page

### DIFF
--- a/app/models/recipient.rb
+++ b/app/models/recipient.rb
@@ -19,4 +19,8 @@ class Recipient < ActiveRecord::Base
   before_validation do
     self.token = SecureRandom.hex 32
   end
+
+  def token_id
+    token[0..5] if token.present?
+  end
 end

--- a/app/models/secret.rb
+++ b/app/models/secret.rb
@@ -55,6 +55,6 @@ private
   end
 
   def send_sms
-    SmsMessage.new(recipient_number: recipient.phone_number, secret_code: encryptor.password).send_message
+    SmsMessage.new(recipient_number: recipient.phone_number, secret_code: encryptor.password, token_id: recipient.token_id).send_message
   end
 end

--- a/app/models/sms_message.rb
+++ b/app/models/sms_message.rb
@@ -3,6 +3,7 @@ class SmsMessage
   include ActiveModel::Validations
 
   validates :recipient_number, format: { with: /\A\d+\z/ }, presence: true, length: { is: 10 }
+  validates :token_id, :secret_code, presence: true
 
   attr_accessor :prompt_pass_number, :recipient_number, :secret_code, :token_id, :twilio_sid, :twilio_token
 

--- a/app/models/sms_message.rb
+++ b/app/models/sms_message.rb
@@ -4,7 +4,7 @@ class SmsMessage
 
   validates :recipient_number, format: { with: /\A\d+\z/ }, presence: true, length: { is: 10 }
 
-  attr_accessor :prompt_pass_number, :recipient_number, :secret_code, :twilio_sid, :twilio_token
+  attr_accessor :prompt_pass_number, :recipient_number, :secret_code, :token_id, :twilio_sid, :twilio_token
 
   def initialize(args = {})
     args = args.merge defaults
@@ -17,7 +17,7 @@ class SmsMessage
     client.messages.create(
       from: prompt_pass_number,
       to: "+1#{recipient_number}",
-      body: "#{I18n.t("sms.text")} #{secret_code}"
+      body: "#{I18n.t("sms.text")} #{secret_code}, for secret #{token_id}"
     )
   end
 

--- a/app/views/recipients/secrets/new.html.erb
+++ b/app/views/recipients/secrets/new.html.erb
@@ -1,7 +1,7 @@
 <div class="row access-code-wrapper">
   <div class="large-6 medium-8 small-12 columns medium-centered pt1">
     <h3>Looks like you're trying to view your secret message.</h3>
-    <p class="text-center">Just enter the code that was sent to your phone.</p>
+    <p class="text-center">Just enter the code that was sent to your phone for secret <%= recipient.token_id %></p>
     <%= simple_form_for secret, url: recipient_secrets_path, method: :post, html: { class: :pt1 } do |f| %>
       <div class="row">
         <div class="medium-10 columns medium-centered">

--- a/app/views/recipients/secrets/new.html.erb
+++ b/app/views/recipients/secrets/new.html.erb
@@ -1,7 +1,7 @@
 <div class="row access-code-wrapper">
   <div class="large-6 medium-8 small-12 columns medium-centered pt1">
     <h3>Looks like you're trying to view your secret message.</h3>
-    <p class="text-center">Just enter the code that was sent to your phone for secret <%= recipient.token_id %></p>
+    <p class="text-center">Just enter the code that was sent to your phone for secret <%= recipient.token_id %>.</p>
     <%= simple_form_for secret, url: recipient_secrets_path, method: :post, html: { class: :pt1 } do |f| %>
       <div class="row">
         <div class="medium-10 columns medium-centered">

--- a/spec/features/recipients/secrets_spec.rb
+++ b/spec/features/recipients/secrets_spec.rb
@@ -66,6 +66,12 @@ describe "recipient secret form" do
       end
     end
 
+    context "token id" do
+      it "shows the token id of the recipient" do
+        expect(page).to have_content secret.recipient.token_id
+      end
+    end
+
     context "there are no errors on the form" do
       before(:each) do
         fill_in "secret_password", with: valid_password

--- a/spec/models/recipient_spec.rb
+++ b/spec/models/recipient_spec.rb
@@ -90,4 +90,19 @@ describe Recipient do
     end
   end
 
+  describe "#token_id" do
+    context "token is set" do
+      it "returns the first 5 chars of the token" do
+        subject.valid?
+        expect(subject.token_id).to eq subject.token[0..5]
+      end
+    end
+
+    context "token is not set" do
+      it "returns the first 5 chars of the token" do
+        expect(subject.token_id).to eq nil
+      end
+    end
+  end
+
 end

--- a/spec/models/sms_message_spec.rb
+++ b/spec/models/sms_message_spec.rb
@@ -1,9 +1,10 @@
 describe SmsMessage do
   describe "validations" do
     it "should pass" do
+      token_id = "5hg83"
       stub_const("Twilio::REST::Client", FakeSms)
-      message = SmsMessage.new({recipient_number:'7809072962'})
-      expect(message.send_message.last.from[:body]).to eq "#{I18n.t("sms.text")} #{message.secret_code}"
+      message = SmsMessage.new({recipient_number:'7809072962', secret_code: '10293', token_id: token_id})
+      expect(message.send_message.last.from[:body]).to eq "#{I18n.t("sms.text")} #{message.secret_code}, for secret #{token_id}"
     end
 
     it "should fail" do


### PR DESCRIPTION
* because if the user gets more than one secret it will get confuse
if there is not a way to relate the sms to a secret.