### PR TITLE
Sendgrid minus tracking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,9 @@ gem 'draper'
 # simple forms
 gem 'simple_form'
 
+# email
+gem 'sendgrid'
+
 group :test do
   gem 'simplecov', require: false
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sendgrid (1.2.0)
+      json
     simple_form (3.2.0)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
@@ -249,6 +251,7 @@ DEPENDENCIES
   rollbar (~> 2.4.0)
   rspec-rails (~> 3.0)
   sass-rails (~> 5.0)
+  sendgrid
   simple_form
   simplecov
   spring

--- a/app/mailers/secret_mailer.rb
+++ b/app/mailers/secret_mailer.rb
@@ -1,9 +1,8 @@
 class SecretMailer < ApplicationMailer
   include SendGrid
 
-  sendgrid_disable :opentrack, :clicktrack, :ganalytics
-
   def new_secret_email(args = {})
+    sendgrid_disable :opentrack, :clicktrack, :ganalytics
     @secret = args.fetch(:secret, nil).try(:decorate)
     mail(to: @secret.recipient.email, subject: I18n.t("mailer.new_secret_email.subject"))
   end

--- a/app/mailers/secret_mailer.rb
+++ b/app/mailers/secret_mailer.rb
@@ -1,4 +1,7 @@
 class SecretMailer < ApplicationMailer
+  include SendGrid
+
+  sendgrid_disable :opentrack, :clicktrack, :ganalytics
 
   def new_secret_email(args = {})
     @secret = args.fetch(:secret, nil).try(:decorate)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,13 +83,13 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   ActionMailer::Base.smtp_settings = {
-    port:             '587',
-    address:          'smtp.mandrillapp.com',
-    user_name:        ENV['MANDRILL_USERNAME'],
-    password:         ENV['MANDRILL_APIKEY'],
-    domain:           'heroku.com',
-    authentication:   :plain
+    address:                  'smtp.sendgrid.net',
+    port:                     '587',
+    authentication:           :plain,
+    user_name:                ENV['SENDGRID_USERNAME'],
+    password:                 ENV['SENDGRID_PASSWORD'],
+    enable_starttls_auto:     true
   }
-  ActionMailer::Base.delivery_method = :smtp
+
   config.action_mailer.default_url_options = { host: Rails.configuration.promptpass_site }
 end


### PR DESCRIPTION
Had to use the sendgrid gem to set SMTP headers to disable link tracking. Has to be used on a per-method basis.