### PR TITLE
Optional receipt email to sender

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,7 @@
 //= require jquery
 //= require jquery_ujs
 //= require foundation
+//= require secrets
 //= skrollr
 //= require_self
 $(function(){ $(document).foundation(); });

--- a/app/assets/javascripts/secrets/advanced_options.js.coffee
+++ b/app/assets/javascripts/secrets/advanced_options.js.coffee
@@ -1,0 +1,2 @@
+$ ->
+  $("#advanced_options").toggle() if $("#advanced_options span.error").length > 0

--- a/app/assets/javascripts/secrets/index.js
+++ b/app/assets/javascripts/secrets/index.js
@@ -1,0 +1,1 @@
+//= require ./advanced_options

--- a/app/controllers/recipients/secrets_controller.rb
+++ b/app/controllers/recipients/secrets_controller.rb
@@ -11,7 +11,7 @@ module Recipients
 
     def create
       if secret.decrypt
-        secret.destroy unless Rails.env.development?
+        tidy_up
         render :create
       else
         render :new
@@ -19,6 +19,11 @@ module Recipients
     end
 
   private
+
+    def tidy_up
+      secret.sender.try(:send_email)
+      secret.destroy unless Rails.env.development?
+    end
 
     def secret_params
       params.require(:secret).permit(:password)

--- a/app/controllers/secrets_controller.rb
+++ b/app/controllers/secrets_controller.rb
@@ -1,17 +1,24 @@
 class SecretsController < ApplicationController
   expose(:secret, attributes: :secret_params)
 
+  before_action :prep_sender, only: :new
+
   def create
     if secret.save
       redirect_to new_secret_path, notice: I18n.t("notifications.secrets.sent") and return
     else
+      prep_sender
       render :new
     end
   end
 
 private
 
+  def prep_sender
+    secret.build_sender unless secret.sender
+  end
+
   def secret_params
-    params.require(:secret).permit(:body, recipient_attributes: [:email, :phone_number])
+    params.require(:secret).permit(:body, sender_attributes: [:email], recipient_attributes: [:email, :phone_number])
   end
 end

--- a/app/mailers/secret_mailer.rb
+++ b/app/mailers/secret_mailer.rb
@@ -1,9 +1,15 @@
 class SecretMailer < ApplicationMailer
   include SendGrid
 
-  def new_secret_email(args = {})
+  def secret_created(args = {})
     sendgrid_disable :opentrack, :clicktrack, :ganalytics
     @secret = args.fetch(:secret, nil).try(:decorate)
-    mail(to: @secret.recipient.email, subject: I18n.t("mailer.new_secret_email.subject"))
+    mail(to: @secret.recipient.email, subject: I18n.t("mailer.secret_created.subject"))
+  end
+
+  def secret_received(args = {})
+    sendgrid_disable :opentrack, :clicktrack, :ganalytics
+    @secret = args.fetch(:secret, nil).try(:decorate)
+    mail(to: @secret.sender.email, subject: I18n.t("mailer.secret_received.subject"))
   end
 end

--- a/app/models/recipient.rb
+++ b/app/models/recipient.rb
@@ -1,6 +1,8 @@
 class Recipient < ActiveRecord::Base
   belongs_to :secret
 
+  attr_accessor :encryptor
+
   normalize_attribute :phone_number, with: :phone
   normalize_attribute :email
 
@@ -22,5 +24,17 @@ class Recipient < ActiveRecord::Base
 
   def token_id
     token[0..5] if token.present?
+  end
+
+  def send_notifications
+    send_email and send_sms
+  end
+
+  def send_email
+    SecretMailer.secret_created(secret: secret).deliver_now
+  end
+
+  def send_sms
+    SmsMessage.new(recipient_number: phone_number, secret_code: encryptor.password, token_id: token_id).send_message
   end
 end

--- a/app/models/sender.rb
+++ b/app/models/sender.rb
@@ -1,0 +1,20 @@
+class Sender < ActiveRecord::Base
+  belongs_to :secret
+
+  normalize_attribute :email
+
+  validates :token,
+            presence: true
+
+  validates :email,
+            presence: true,
+            format: { with: /\A[^`@\s]+@([^@`\s\.]+\.)+[^`@\s\.]+\z/, message: I18n.t("errors.messages.email"), allow_nil: true }
+
+  before_validation do
+    self.token = SecureRandom.hex 32
+  end
+
+  def send_email
+    SecretMailer.secret_received(secret: secret).deliver_now
+  end
+end

--- a/app/views/recipients/secrets/new.html.erb
+++ b/app/views/recipients/secrets/new.html.erb
@@ -10,7 +10,7 @@
       </div>
       <div class="row">
         <div class="medium-10 columns medium-centered">
-          <%= f.button :button, I18n.t("forms.secrets.decrypt_button"), class: "submit" %>
+          <%= f.button :button, I18n.t("forms.secrets.decrypt_button"), class: "submit", data: { disable_with: 'Decrypting...' } %>
         </div>
       </div>
     <% end %>

--- a/app/views/secret_mailer/secret_created.html.erb
+++ b/app/views/secret_mailer/secret_created.html.erb
@@ -1,4 +1,1 @@
 Your secret access code was sent to <strong><%= @secret.recipient.phone_number %></strong>. Click <a href="<%= @secret.secret_url %>">here</a> to view your secret message.
-<br/>
-<br/>
-<a href="https://www.prompt-pass.com/about">About Pass Prompt</a>

--- a/app/views/secret_mailer/secret_received.html.erb
+++ b/app/views/secret_mailer/secret_received.html.erb
@@ -1,0 +1,1 @@
+Your secret message was received and read by <strong><%= @secret.recipient.email %></strong>. Thank you for using Prompt Pass.

--- a/app/views/secrets/new.html.erb
+++ b/app/views/secrets/new.html.erb
@@ -17,12 +17,26 @@
       </div>
       <div class="row">
         <div class="large-12 columns">
+          <ul class="accordion" data-accordion>
+            <li class="accordion-navigation">
+              <a href="#advanced_options">Advanced Options</a>
+              <div id="advanced_options" class="content">
+                <%= f.simple_fields_for :sender do |sf| %>
+                  <%= sf.input :email, type: 'email', placeholder: I18n.t("forms.placeholders.email"), label: "Send A Viewed Notification After The Message Is Received To" %>
+                <% end %>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div class="row">
+        <div class="large-12 columns mt1">
           <%= f.input :body, as: :text, input_html: { rows: 18, cols: 150 }, placeholder: "Type a secret message!", label: "Secret Message" %>
         </div>
       </div>
       <div class="row">
         <div class="large-12 columns">
-          <%= f.button :button, I18n.t("forms.secrets.submit_button"), class: "submit" %>
+          <%= f.button :button, I18n.t("forms.secrets.submit_button"), class: "submit", data: { disable_with: 'Sending...' } %>
         </div>
       </div>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,7 +44,9 @@ en:
       decryption: "We were unable to decrypt the message. Message will be destroyed after 5 attempts - %{decryption_count} of 5."
       decryption_destroy: "Maximum number of tries exceeded. The secret message has been destroyed."
   mailer:
-    new_secret_email:
-      subject: "Pass Prompt | You've been sent a secret message."
+    secret_created:
+      subject: "Prompt Pass | You've been sent a secret message."
+    secret_received:
+      subject: "Prompt Pass | Your secret message has been received."
   sms:
     text: "Prompt Pass secret access code:"

--- a/db/migrate/20151108164324_create_senders.rb
+++ b/db/migrate/20151108164324_create_senders.rb
@@ -1,0 +1,11 @@
+class CreateSenders < ActiveRecord::Migration
+  def change
+    create_table :senders do |t|
+      t.string     :email
+      t.string     :token, index: true
+      t.references :secret, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151108160748) do
+ActiveRecord::Schema.define(version: 20151108164324) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,5 +35,16 @@ ActiveRecord::Schema.define(version: 20151108160748) do
     t.string   "encryption_salt"
     t.integer  "decryption_attempt", default: 0
   end
+
+  create_table "senders", force: :cascade do |t|
+    t.string   "email"
+    t.string   "token"
+    t.integer  "secret_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "senders", ["secret_id"], name: "index_senders_on_secret_id", using: :btree
+  add_index "senders", ["token"], name: "index_senders_on_token", using: :btree
 
 end

--- a/spec/factories/secrets.rb
+++ b/spec/factories/secrets.rb
@@ -3,5 +3,6 @@ FactoryGirl.define do
     body "test"
     encrypted_body "WERFLERS ER JERST PLERN FERNTERSTERC. TRER THERM!"
     association :recipient
+    association :sender
   end
 end

--- a/spec/factories/sender.rb
+++ b/spec/factories/sender.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :sender do
+    email "bruce.wayne@gotham.com"
+  end
+end

--- a/spec/features/secrets_spec.rb
+++ b/spec/features/secrets_spec.rb
@@ -103,16 +103,59 @@ describe "secret form" do
         end
       end
     end
+
+    describe "#sender" do
+      describe "#email" do
+        context "has been filled out with an invalid value" do
+          before(:each) do
+            find("a[href='#advanced_options']").click
+            fill_in "secret_sender_attributes_email", with: "waffles"
+            click_button submit_button
+          end
+
+          it "shows a required field error" do
+            within("div.secret_sender_email") do
+              expect(page).to have_content email_error
+            end
+          end
+
+          it "does not show us a success message" do
+            expect(page).to_not have_content I18n.t("notifications.secrets.sent")
+          end
+
+          it "expands the #advanced_options accordion" do
+            expect(page).to have_selector("#secret_sender_attributes_email", visible: true)
+          end
+        end
+      end
+    end
   end
 
   context "there are no errors on the form" do
     before(:each) do
       stub_const("Twilio::REST::Client", FakeSms)
-      click_button submit_button
     end
 
-    it "shows us a success message" do
-      expect(page).to have_content I18n.t("notifications.secrets.sent")
+    context "there is no sender" do
+      before(:each) do
+        click_button submit_button
+      end
+
+      it "shows us a success message" do
+        expect(page).to have_content I18n.t("notifications.secrets.sent")
+      end
+    end
+
+    context "there is a sender" do
+      before(:each) do
+        find("a[href='#advanced_options']").click
+        fill_in "secret_sender_attributes_email", with: "ilikesecretstoo@secrets.com"
+        click_button submit_button
+      end
+
+      it "shows us a success message" do
+        expect(page).to have_content I18n.t("notifications.secrets.sent")
+      end
     end
   end
 end

--- a/spec/mailers/secret_mailer_spec.rb
+++ b/spec/mailers/secret_mailer_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe SecretMailer, type: :mailer do
     stub_const("Twilio::REST::Client", FakeSms)
   end
 
-  describe "#new_secret_email" do
-    let(:mail) { SecretMailer.new_secret_email(secret: secret) }
+  describe "#secret_created" do
+    let(:mail) { SecretMailer.secret_created(secret: secret) }
 
     context "email headers" do
       it "render the headers" do
-        expect(mail.subject).to eq I18n.t("mailer.new_secret_email.subject")
+        expect(mail.subject).to eq I18n.t("mailer.secret_created.subject")
         expect(mail.to).to eq ["#{secret.recipient.email}"]
         expect(mail.from).to eq ["secretkeeper@prompt-pass.com"]
       end
@@ -22,6 +22,24 @@ RSpec.describe SecretMailer, type: :mailer do
       end
 
       xit "render the secret time span" do
+      end
+    end
+  end
+
+  describe "#secret_received" do
+    let(:mail) { SecretMailer.secret_received(secret: secret) }
+
+    context "email headers" do
+      it "render the headers" do
+        expect(mail.subject).to eq I18n.t("mailer.secret_received.subject")
+        expect(mail.to).to eq ["#{secret.sender.email}"]
+        expect(mail.from).to eq ["secretkeeper@prompt-pass.com"]
+      end
+    end
+
+    context "email body" do
+      it "render the secret url" do
+        expect(mail.body.encoded).to match "Your secret message was received and read by <strong>#{secret.recipient.email}</strong>"
       end
     end
   end

--- a/spec/models/sender_spec.rb
+++ b/spec/models/sender_spec.rb
@@ -1,0 +1,45 @@
+describe Sender do
+  describe "#email" do
+    context "must be present" do
+      let(:error_message) { I18n.t "errors.messages.blank" }
+
+      it "sets an error message" do
+        subject.email = nil
+        subject.valid?
+        expect(subject.errors[:email]).to include error_message
+      end
+    end
+
+    context "must be present" do
+      let(:error_message) { I18n.t "errors.messages.blank" }
+
+      it "sets an error message" do
+        subject.email = nil
+        subject.valid?
+        expect(subject.errors[:email]).to include error_message
+      end
+    end
+
+    context "must be present" do
+      let(:error_message) { I18n.t "errors.messages.email" }
+
+      it "sets an error message" do
+        subject.email = "8675309"
+        subject.valid?
+        expect(subject.errors[:email]).to include error_message
+      end
+    end
+  end
+
+  describe "#token" do
+    context "must be present" do
+      let(:error_message) { I18n.t "errors.messages.blank" }
+
+      it "sets an error message" do
+        allow(subject).to receive(:token).and_return nil
+        subject.valid?
+        expect(subject.errors[:token]).to include error_message
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adding feature for optionally sending a receipt email to the creator of the secret when the recipient opens it.

Did a little bit of refactoring on the recipient email. Most of the email concern is moved into the recipient itself. Sender operated in the same way.
Keep Advanced Settings accordion open if there are errors. Only rebuild the sender if it has been nuked during form submission.
Disable buttons with javascript and contextual text while forms are submitting.
Removed About link from emails.