### PR TITLE
More SMS message clarity

### DIFF
--- a/app/models/sms_message.rb
+++ b/app/models/sms_message.rb
@@ -18,7 +18,9 @@ class SmsMessage
     client.messages.create(
       from: prompt_pass_number,
       to: "+1#{recipient_number}",
-      body: "#{I18n.t("sms.text")} #{secret_code}, for secret #{token_id}"
+      body: "#{I18n.t("sms.text")} #{secret_code}.\n"\
+            "An email with a link to your secret message will arrive shortly.\n"\
+            "(secret-#{token_id})"
     )
   end
 

--- a/app/views/recipients/secrets/new.html.erb
+++ b/app/views/recipients/secrets/new.html.erb
@@ -1,7 +1,7 @@
 <div class="row access-code-wrapper">
   <div class="large-6 medium-8 small-12 columns medium-centered pt1">
     <h3>Looks like you're trying to view your secret message.</h3>
-    <p class="text-center">Just enter the code that was sent to your phone for secret <%= recipient.token_id %>.</p>
+    <p class="text-center">Just enter the code that was sent to your phone for secret-<%= recipient.token_id %>.</p>
     <%= simple_form_for secret, url: recipient_secrets_path, method: :post, html: { class: :pt1 } do |f| %>
       <div class="row">
         <div class="medium-10 columns medium-centered">

--- a/spec/models/sms_message_spec.rb
+++ b/spec/models/sms_message_spec.rb
@@ -1,16 +1,29 @@
 describe SmsMessage do
   describe "validations" do
-    it "should pass" do
-      token_id = "5hg83"
+    let(:token_id) { "5hg83" }
+
+    before(:each) do
       stub_const("Twilio::REST::Client", FakeSms)
-      message = SmsMessage.new({recipient_number:'7809072962', secret_code: '10293', token_id: token_id})
-      expect(message.send_message.last.from[:body]).to eq "#{I18n.t("sms.text")} #{message.secret_code}, for secret #{token_id}"
     end
 
-    it "should fail" do
-      expect { SmsMessage.new({recipient_number:'+17809072962'}).send_message }.to raise_error RuntimeError
-      expect { SmsMessage.new({}).send_message }.to raise_error RuntimeError
-      expect { SmsMessage.new({recipient_number:'9072962'}).send_message }.to raise_error RuntimeError
+    context "validation successful" do
+      let(:message) { SmsMessage.new({recipient_number:'7809072962', secret_code: '10293', token_id: token_id}) }
+
+      it "sends a message with the secret_code" do
+        expect(message.send_message.last.from[:body]).to include "#{I18n.t("sms.text")} #{message.secret_code}"
+      end
+
+      it "sends a message with the token_id" do
+        expect(message.send_message.last.from[:body]).to include token_id
+      end
+    end
+
+    context "validation unsuccessful" do
+      it "should fail" do
+        expect { SmsMessage.new({recipient_number:'+17809072962'}).send_message }.to raise_error RuntimeError
+        expect { SmsMessage.new({}).send_message }.to raise_error RuntimeError
+        expect { SmsMessage.new({recipient_number:'9072962'}).send_message }.to raise_error RuntimeError
+      end
     end
   end
 end


### PR DESCRIPTION
Secret identifier is now secret-{somehex}, and is the last part of the SMS message to help keep people from mistaking that for the Access Code.

Added text to the SMS explaining that an email with a link to the Secret Message would arrive shortly.